### PR TITLE
Update grass to release

### DIFF
--- a/src/grass/osgeo4w/package.sh
+++ b/src/grass/osgeo4w/package.sh
@@ -1,8 +1,13 @@
 export P=grass
-export V=7.8.6RC2
+
+export V=7.8.6
 export B=next
 export MAINTAINER=JuergenFischer
 export BUILDDEPENDS="gdal-devel proj-devel geos-devel libjpeg-devel libpng-devel libpq-devel libtiff-devel sqlite3-devel zstd-devel python3-core python3-six python3-pywin32 liblas-devel python3-wxpython"
+
+if [ "$CI" ] ; then
+cd "$OSGEO4W_PWD"
+fi
 
 source ../../../scripts/build-helpers
 
@@ -15,6 +20,7 @@ MM=${MM//./}
 
 [ -f $P-$V.tar.gz ] || wget -O $P-$V.tar.gz https://github.com/OSGeo/$P/archive/refs/tags/$V.tar.gz
 [ -f ../$P-$V/configure ] || tar -C .. -xzf $P-$V.tar.gz
+
 [ -f ../$P-$V/patched ] || {
 	patch -l -d ../$P-$V -p1 --dry-run <patch
 	patch -l -d ../$P-$V -p1 <patch
@@ -39,9 +45,9 @@ msysarch=msys2-base-x86_64-20210604.tar.xz
 	export PATH="$(cygpath -a msys64/usr/bin):$PATH"
 
 	[ -f msys64/msys2.init ] || {
-		cmd.exe /c bash pacman-key --init
-		cmd.exe /c bash pacman-key --populate msys2
-		cmd.exe /c bash /etc/profile
+		cmd.exe /c "bash pacman-key --init"
+		cmd.exe /c "bash pacman-key --populate msys2"
+		cmd.exe /c "bash /etc/profile"
 		touch msys64/msys2.init
 	}
 
@@ -72,7 +78,7 @@ msysarch=msys2-base-x86_64-20210604.tar.xz
 
 	cd ../$P-$V
 
-	cmd.exe /c $(cygpath -aw $OSGEO4W_PWD/msys64/usr/bin/bash) $xtrace mswindows/osgeo4w/package.sh
+	cmd.exe /c "$(cygpath -aw $OSGEO4W_PWD/msys64/usr/bin/bash) $xtrace mswindows/osgeo4w/package.sh"
 )
 
 export R=$OSGEO4W_REP/x86_64/release/$P
@@ -82,8 +88,8 @@ cp ../$P-$V/mswindows/osgeo4w/package/$P-$V-1.tar.bz2 $R/$P-$V-$B.tar.bz2
 cp ../$P-$V/COPYING $R/$P-$V-$B.txt
 
 cat <<EOF >$R/setup.hint
-sdesc: "GRASS GIS"
-ldesc: "Geographic Resources Analysis Support System (GRASS GIS)"
+sdesc: "GRASS GIS 7.8"
+ldesc: "Geographic Resources Analysis Support System (GRASS GIS) 7.8"
 category: Desktop
 requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel gs python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32
 maintainer: $MAINTAINER


### PR DESCRIPTION
Meanwhile, GRASS 7.8.6 is released by @landam .

The github action I run based on the `package.sh` code in this PR builds GRASS 7.8.6 just fine:
https://github.com/ninsbl/OSGeo4W/runs/3853112367?check_suite_focus=true

Please let me know if there is an opening for getting the changes integrated that make the OSGeo4W build usable in GRASS GIS CI ...

Replaces #4 