### PR TITLE
Add pyserial package

### DIFF
--- a/src/python3-pyserial/osgeo4w/package.sh
+++ b/src/python3-pyserial/osgeo4w/package.sh
@@ -1,0 +1,13 @@
+export P=python3-pyserial
+export V=pip
+export B=pip
+export MAINTAINER=Lo
+export BUILDDEPENDS="python3-pip python3-wheel python3-setuptools"
+
+source ../../../scripts/build-helpers
+
+startlog
+
+packagewheel
+
+endlog


### PR DESCRIPTION
pyserial is the de facto python library to communicate with serial (usb,  RS-232, etc) ports. It's used in several QGIS plugins. It's useful to embed this plugin in osgeo4w instead of each plugins.