### PR TITLE
Fix setting GDAL_DATA in gdal-dev-env.bat

### DIFF
--- a/src/gdal-dev/osgeo4w/package.sh
+++ b/src/gdal-dev/osgeo4w/package.sh
@@ -259,7 +259,7 @@ EOF
 
 mkdir -p install/bin
 cat <<EOF >install/bin/$P-env.bat
-SET GDAL_DATA=%OSGEO4W_ROOT%\\share\\$P
+SET GDAL_DATA=%OSGEO4W_ROOT%\\apps\\$P\\share\\gdal
 SET GDAL_DRIVER_PATH=%OSGEO4W_ROOT%\\apps\\$P\\lib\\gdalplugins
 PATH %OSGEO4W_ROOT%\\apps\\$P\\bin;%PATH%
 EOF


### PR DESCRIPTION
The GDAL_DATA env var is currently set to the non existent `\share\gdal-dev` folder by `gdal-dev-env.bat`, while it should be set to `\apps\gdal-dev\share\gdal`.