### PR TITLE
GRASS GIS: add git dependency

### DIFF
--- a/src/grass-dev/osgeo4w/package.sh
+++ b/src/grass-dev/osgeo4w/package.sh
@@ -169,7 +169,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*} nightly"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*} nightly)"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs netcdf wxwidgets
+requires: liblas $RUNTIMEDEPENDS avce00 git gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs netcdf wxwidgets
 maintainer: $MAINTAINER
 EOF
 

--- a/src/grass/osgeo4w/package.sh
+++ b/src/grass/osgeo4w/package.sh
@@ -117,7 +117,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*}"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*})"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs
+requires: liblas $RUNTIMEDEPENDS avce00 git gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs
 maintainer: $MAINTAINER
 EOF
 

--- a/src/grass8/osgeo4w/package.sh
+++ b/src/grass8/osgeo4w/package.sh
@@ -119,7 +119,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*}"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*})"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs netcdf wxwidgets
+requires: liblas $RUNTIMEDEPENDS avce00 git gpsbabel proj python3-gdal python3-matplotlib libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2-binary python3-six zstd python3-pywin32 gs netcdf wxwidgets
 maintainer: $MAINTAINER
 EOF
 


### PR DESCRIPTION
Recently, git was added as a dependency to GRASS GIS, required to install addons, as SVN is about to sunset and the earlier use of GitHub API had limitations.
Changes will eventually be backported also to GRASS GIS 7, so git is added as a dependency also there already.