### PR TITLE
Python: Add psycopg3

### DIFF
--- a/python3-psycopg/osgeo4w/package.sh
+++ b/python3-psycopg/osgeo4w/package.sh
@@ -1,0 +1,13 @@
+export P=python3-psycopg
+export V=pip
+export B=pip
+export MAINTAINER=LoicBartoletti
+export BUILDDEPENDS="python3-pip python3-wheel python3-setuptools"
+
+source ../../../scripts/build-helpers
+
+startlog
+
+packagewheel
+
+endlog


### PR DESCRIPTION
Psycopg3 has been released since 2021-10-13, we now advise against using psycopg2. 
I suggest adding psycopg3 as psycopg (as it is on pypi). I haven't tested the package, but there's a wheel for windows that should work like the others.