### PR TITLE
Fix installation logs

### DIFF
--- a/src/qt5/osgeo4w/package.sh
+++ b/src/qt5/osgeo4w/package.sh
@@ -262,7 +262,6 @@ mkdir -p $R/$P-{devel,qml,tools,docs,libs,libs-symbols,oci}
 #
 
 cat <<EOF >../qt5.bat
-@echo off
 path %OSGEO4W_ROOT%\\apps\\qt5\\bin;%PATH%
 
 set QT_PLUGIN_PATH=%OSGEO4W_ROOT%\\apps\\Qt5\\plugins


### PR DESCRIPTION
Remove `@echo off` from etc\ini\qt5.bat in order to save in the installation logs the commands executed by qt5.bat itself and by etc\postinstall\qgis-common.bat and other batch files after the call "%OSGEO4W_ROOT%\bin\o4w_env.bat" line.
See the "side note" in https://trac.osgeo.org/osgeo4w/ticket/828#comment:7