### PR TITLE
grass, grass-dev: use libgomp for OpenMP support

### DIFF
--- a/src/grass-dev/osgeo4w/package.sh
+++ b/src/grass-dev/osgeo4w/package.sh
@@ -155,7 +155,6 @@ pacman --noconfirm -Syu --needed \
 	mingw-w64-x86_64-pcre \
 	mingw-w64-x86_64-fftw \
 	mingw-w64-x86_64-openblas \
-	mingw-w64-x86_64-openmp \
 	mingw-w64-x86_64-readline
 
 cd ../grass

--- a/src/grass-dev/osgeo4w/patch
+++ b/src/grass-dev/osgeo4w/patch
@@ -1,29 +1,3 @@
-diff --git a/include/Make/Grass.make b/include/Make/Grass.make
-index 137a45d19..4f26feda2 100644
---- a/include/Make/Grass.make
-+++ b/include/Make/Grass.make
-@@ -197,7 +197,7 @@ DSPFDEPS         = $(GISLIB)
- FORMDEPS         = $(DBMILIB) $(GISLIB)
- RASTER3DDEPS     = $(RASTERLIB) $(GISLIB)
- GISDEPS          = $(DATETIMELIB) $(ZLIBLIBPATH) $(ZLIB) $(BZIP2LIBPATH) $(BZIP2LIB) $(ZSTDLIBPATH) $(ZSTDLIB) $(INTLLIB) $(REGEXLIBPATH) $(REGEXLIB) $(ICONVLIB) $(PTHREADLIBPATH) $(PTHREADLIB) $(MATHLIB)
--GMATHDEPS        = $(GISLIB) $(FFTWLIB) $(LAPACKLIB) $(BLASLIB) $(CCMATHLIB) $(OPENMP_CFLAGS) $(OPENMP_LIBPATH) $(OPENMP_LIB)
-+GMATHDEPS        = $(GISLIB) $(FFTWLIB) $(LAPACKLIB) $(BLASLIB) $(CCMATHLIB) $(OPENMP_LIBPATH) $(OPENMP_LIB)
- GPDEDEPS         = $(RASTER3DLIB) $(RASTERLIB) $(GISLIB) $(GMATHLIB) $(OPENMP_LIBPATH) $(OPENMP_LIB) $(MATHLIB)
- GPROJDEPS        = $(GISLIB) $(GDALLIBS) $(PROJLIB) $(MATHLIB)
- HTMLDRIVERDEPS   = $(DRIVERLIB) $(GISLIB) $(MATHLIB)
-diff --git a/include/Make/Platform.make.in b/include/Make/Platform.make.in
-index a66ddf801..1f08f7771 100644
---- a/include/Make/Platform.make.in
-+++ b/include/Make/Platform.make.in
-@@ -228,7 +228,7 @@ USE_PTHREAD         = @USE_PTHREAD@
- #OpenMP
- OPENMP_INCPATH      = @OPENMP_INCPATH@
- OPENMP_LIBPATH      = @OPENMP_LIBPATH@
--OPENMP_LIB          = @OPENMP_LIB@
-+OPENMP_LIB          = @OPENMP_CFLAGS@ @OPENMP_LIB@
- OPENMP_CFLAGS       = @OPENMP_CFLAGS@
- USE_OPENMP          = @USE_OPENMP@
- 
 diff --git a/mswindows/osgeo4w/env.bat.tmpl b/mswindows/osgeo4w/env.bat.tmpl
 index 200c86f26..86bf4a3a0 100644
 --- a/mswindows/osgeo4w/env.bat.tmpl
@@ -52,10 +26,10 @@ index f00a136be..e8d8be2f6 100755
  libdir="${prefix}/lib"
  includedir="${prefix}/include/libpng${dll_version}"
 diff --git a/mswindows/osgeo4w/package.sh b/mswindows/osgeo4w/package.sh
-index c189cf92c..fcab3e242 100755
+index c189cf92c9..fcb69a8ae3 100755
 --- a/mswindows/osgeo4w/package.sh
 +++ b/mswindows/osgeo4w/package.sh
-@@ -108,26 +108,17 @@ exec 3>&1 > >(tee mswindows/osgeo4w/package.log) 2>&1
+@@ -108,26 +108,16 @@ exec 3>&1 > >(tee mswindows/osgeo4w/package.log) 2>&1
  
  DLLS="
  	/mingw64/bin/libblas.dll
@@ -78,13 +52,12 @@ index c189cf92c..fcab3e242 100755
 -	/mingw64/bin/libpcre-1.dll
 -	/mingw64/bin/libpixman-1-0.dll
 -	/mingw64/bin/libpng16-16.dll
-+	/mingw64/bin/libomp.dll
  	/mingw64/bin/libquadmath-0.dll
 +	/mingw64/bin/libreadline8.dll
  	/mingw64/bin/libstdc++-6.dll
  	/mingw64/bin/libsystre-0.dll
  	/mingw64/bin/libtre-5.dll
-@@ -153,40 +144,41 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
+@@ -153,40 +143,41 @@ if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
  
  	log configure
  	./configure \
@@ -140,7 +113,7 @@ index c189cf92c..fcab3e242 100755
  		--with-regex \
  		--with-sqlite \
  		--with-sqlite-includes=$OSGEO4W_ROOT_MSYS/include \
-@@ -248,7 +240,9 @@ if [ -n "$PACKAGE_PATCH" ]; then
+@@ -248,7 +239,9 @@ if [ -n "$PACKAGE_PATCH" ]; then
  
      # copy dependencies (TODO: to be reduced)
      cp -uv $DLLS apps/grass/grass$POSTFIX/bin

--- a/src/grass/osgeo4w/package.sh
+++ b/src/grass/osgeo4w/package.sh
@@ -101,7 +101,6 @@ pacman --noconfirm -Syu --needed \
 	mingw-w64-x86_64-pcre \
 	mingw-w64-x86_64-fftw \
 	mingw-w64-x86_64-lapack \
-	mingw-w64-x86_64-openmp \
 	mingw-w64-x86_64-readline
 
 cd ../$p

--- a/src/grass/osgeo4w/patch
+++ b/src/grass/osgeo4w/patch
@@ -1,27 +1,3 @@
-diff -ur grass-8.4.0/include/Make/Grass.make ../grass-8.4.0/include/Make/Grass.make
---- grass-8.4.0/include/Make/Grass.make	2024-07-27 13:27:22.000000000 +0200
-+++ ../grass-8.4.0/include/Make/Grass.make	2024-08-05 11:27:31.639581200 +0200
-@@ -197,7 +197,7 @@
- FORMDEPS         = $(DBMILIB) $(GISLIB)
- RASTER3DDEPS     = $(RASTERLIB) $(GISLIB)
- GISDEPS          = $(DATETIMELIB) $(ZLIBLIBPATH) $(ZLIB) $(BZIP2LIBPATH) $(BZIP2LIB) $(ZSTDLIBPATH) $(ZSTDLIB) $(INTLLIB) $(REGEXLIBPATH) $(REGEXLIB) $(ICONVLIB) $(PTHREADLIBPATH) $(PTHREADLIB) $(MATHLIB)
--GMATHDEPS        = $(GISLIB) $(FFTWLIB) $(LAPACKLIB) $(BLASLIB) $(CCMATHLIB) $(OPENMP_CFLAGS) $(OPENMP_LIBPATH) $(OPENMP_LIB)
-+GMATHDEPS        = $(GISLIB) $(FFTWLIB) $(LAPACKLIB) $(BLASLIB) $(CCMATHLIB) $(OPENMP_LIBPATH) $(OPENMP_LIB)
- GPDEDEPS         = $(RASTER3DLIB) $(RASTERLIB) $(GISLIB) $(GMATHLIB) $(OPENMP_LIBPATH) $(OPENMP_LIB) $(MATHLIB)
- GPROJDEPS        = $(GISLIB) $(GDALLIBS) $(PROJLIB) $(MATHLIB)
- HTMLDRIVERDEPS   = $(DRIVERLIB) $(GISLIB) $(MATHLIB)
-diff -ur grass-8.4.0/include/Make/Platform.make.in ../grass-8.4.0/include/Make/Platform.make.in
---- grass-8.4.0/include/Make/Platform.make.in	2024-07-27 13:27:22.000000000 +0200
-+++ ../grass-8.4.0/include/Make/Platform.make.in	2024-08-05 11:27:31.648583300 +0200
-@@ -234,7 +234,7 @@
- #OpenMP
- OPENMP_INCPATH      = @OPENMP_INCPATH@
- OPENMP_LIBPATH      = @OPENMP_LIBPATH@
--OPENMP_LIB          = @OPENMP_LIB@
-+OPENMP_LIB          = @OPENMP_CFLAGS@ @OPENMP_LIB@
- OPENMP_CFLAGS       = @OPENMP_CFLAGS@
- USE_OPENMP          = @USE_OPENMP@
- 
 diff -ur grass-8.4.0/mswindows/osgeo4w/env.bat.tmpl ../grass-8.4.0/mswindows/osgeo4w/env.bat.tmpl
 --- grass-8.4.0/mswindows/osgeo4w/env.bat.tmpl	2024-07-27 13:27:22.000000000 +0200
 +++ ../grass-8.4.0/mswindows/osgeo4w/env.bat.tmpl	2024-08-05 11:27:31.656582900 +0200
@@ -47,9 +23,9 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/libpng-config ../grass-8.4.0/mswindows/os
  libdir="${prefix}/lib"
  includedir="${prefix}/include/libpng${dll_version}"
 diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo4w/package.sh
---- grass-8.4.0/mswindows/osgeo4w/package.sh	2024-07-27 13:27:22.000000000 +0200
-+++ ../grass-8.4.0/mswindows/osgeo4w/package.sh	2024-08-05 11:27:31.672090000 +0200
-@@ -110,29 +110,20 @@
+--- grass-8.4.0/mswindows/osgeo4w/package.sh	2024-07-27 13:27:22
++++ ../grass-8.4.0/mswindows/osgeo4w/package.sh	2024-11-19 11:21:38
+@@ -110,29 +110,19 @@
  	/mingw64/bin/zlib1.dll
  	/mingw64/bin/libbz2-1.dll
  	/mingw64/bin/libiconv-2.dll
@@ -70,7 +46,6 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo
  	/mingw64/bin/libgomp-1.dll
 -	/mingw64/bin/libgraphite2.dll
 -	/mingw64/bin/libpcre-1.dll
-+	/mingw64/bin/libomp.dll
  	/mingw64/bin/libstdc++-6.dll
  	/mingw64/bin/libgcc_s_seh-1.dll
  	/mingw64/bin/libfftw3-3.dll
@@ -81,7 +56,7 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo
  "
  
  if ! [ -f mswindows/osgeo4w/configure-stamp ]; then
-@@ -148,18 +139,18 @@
+@@ -148,18 +138,18 @@
  	cp -uv $DLLS dist.x86_64-w64-mingw32/bin
  
  	mkdir -p mswindows/osgeo4w/lib
@@ -107,7 +82,7 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo
  		--with-opengl=windows \
  		--without-x \
  		--with-cxx \
-@@ -167,15 +158,16 @@
+@@ -167,15 +157,16 @@
  		--enable-largefile \
  		--with-fftw \
  		--with-freetype \
@@ -130,7 +105,7 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo
  		--with-sqlite \
  		--with-sqlite-includes=$OSGEO4W_ROOT_MSYS/include \
  		--with-sqlite-libs=$PWD/mswindows/osgeo4w/lib \
-@@ -189,10 +181,11 @@
+@@ -189,10 +180,11 @@
  		--with-lapack-includes=/mingw64/include \
  		--with-openmp \
  		--with-cairo \
@@ -144,14 +119,15 @@ diff -ur grass-8.4.0/mswindows/osgeo4w/package.sh ../grass-8.4.0/mswindows/osgeo
  		--without-pdal
  
  	touch mswindows/osgeo4w/configure-stamp
-@@ -248,7 +241,9 @@
+@@ -248,8 +240,10 @@
  
      # copy dependencies (TODO: to be reduced)
      cp -uv $DLLS apps/grass/grass$POSTFIX/bin
 -    cp -uv /mingw64/etc/fonts/fonts.conf apps/grass/grass$POSTFIX/etc
-+
+ 
 +    # copy R batch files
 +    cp -uv $SRC/mswindows/external/rbatch/* apps/grass/grass$POSTFIX/bin
- 
++
      # creating grass package
      /bin/tar -cjf $PDIR/grass$PACKAGE_POSTFIX-$VERSION-$PACKAGE_PATCH.tar.bz2 \
+ 	apps/grass/grass$POSTFIX \


### PR DESCRIPTION
Building GRASS with both libgomp (supplied by `mingw-w64-x86_64-gcc`) and libomp (with `mingw-w64-x86_64-openmp` for Clang and LLVM) causes conflict. This was discussed at e.g. https://github.com/OSGeo/grass/issues/4443.

This PR removes the addition of the mingw-w64-x86_64-openmp package dependency and the patches related to OpenMP are removed.

(I have no means to test this, but these changes should be right).


Side note: there is a PR https://github.com/OSGeo/grass/pull/4716 related to libopenblas which will be needed to account for (for `grass-dev`) when merged.