### PR TITLE
Invoke interactive shell in current working directory

### DIFF
--- a/src/base/OSGeo4W.bat
+++ b/src/base/OSGeo4W.bat
@@ -5,4 +5,4 @@ call "%~dp0\bin\o4w_env.bat"
 rem List available o4w programs
 rem but only if osgeo4w called without parameters
 @echo on
-@if [%1]==[] (echo run o-help for a list of available commands & cd /d "%~dp0" & cmd.exe /k) else (cmd /c "%*")
+@if [%1]==[] (echo run o-help for a list of available commands & cmd.exe /k) else (cmd /c "%*")


### PR DESCRIPTION
This minor change gets the "Start in" working directory going as one may specify in MS Windows shortcuts (.lnk) as done for the OSGeo4W-Shell in the Start Menu