### PR TITLE
qgis qt6: Remove HAS_KDE_QT5_* build flags

### DIFF
--- a/src/qgis-ltr-qt6/osgeo4w/package.sh
+++ b/src/qgis-ltr-qt6/osgeo4w/package.sh
@@ -136,9 +136,6 @@ nextbinary
 		-D WITH_CUSTOM_WIDGETS=TRUE \
 		-D CMAKE_BUILD_TYPE=$BUILDCONF \
 		-D CMAKE_CONFIGURATION_TYPES="$BUILDCONF" \
-		-D HAS_KDE_QT5_PDF_TRANSFORM_FIX=TRUE \
-		-D HAS_KDE_QT5_SMALL_CAPS_FIX=TRUE \
-		-D HAS_KDE_QT5_FONT_STRETCH_FIX=TRUE \
 		-D SETUPAPI_LIBRARY="$(cygpath -am "/cygdrive/c/Program Files (x86)/Windows Kits/10/Lib/$UCRTVersion/um/x64/SetupAPI.Lib")" \
 		-D PROJ_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \
 		-D POSTGRES_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \

--- a/src/qgis-qt6-dev/osgeo4w/package.sh
+++ b/src/qgis-qt6-dev/osgeo4w/package.sh
@@ -193,9 +193,6 @@ nextbinary
 		-D WITH_CUSTOM_WIDGETS=TRUE \
 		-D CMAKE_BUILD_TYPE=$BUILDCONF \
 		-D CMAKE_CONFIGURATION_TYPES="$BUILDCONF" \
-		-D HAS_KDE_QT5_PDF_TRANSFORM_FIX=TRUE \
-		-D HAS_KDE_QT5_SMALL_CAPS_FIX=TRUE \
-		-D HAS_KDE_QT5_FONT_STRETCH_FIX=TRUE \
 		-D SETUPAPI_LIBRARY="$(cygpath -am "/cygdrive/c/Program Files (x86)/Windows Kits/10/Lib/$UCRTVersion/um/x64/SetupAPI.Lib")" \
 		-D PROJ_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \
 		-D POSTGRES_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \

--- a/src/qgis-qt6-ltr-dev/osgeo4w/package.sh
+++ b/src/qgis-qt6-ltr-dev/osgeo4w/package.sh
@@ -209,9 +209,6 @@ nextbinary
 		-D WITH_CUSTOM_WIDGETS=TRUE \
 		-D CMAKE_BUILD_TYPE=$BUILDCONF \
 		-D CMAKE_CONFIGURATION_TYPES="$BUILDCONF" \
-		-D HAS_KDE_QT5_PDF_TRANSFORM_FIX=TRUE \
-		-D HAS_KDE_QT5_SMALL_CAPS_FIX=TRUE \
-		-D HAS_KDE_QT5_FONT_STRETCH_FIX=TRUE \
 		-D SETUPAPI_LIBRARY="$(cygpath -am "/cygdrive/c/Program Files (x86)/Windows Kits/10/Lib/$UCRTVersion/um/x64/SetupAPI.Lib")" \
 		-D PROJ_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \
 		-D POSTGRES_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \

--- a/src/qgis-qt6-rel-dev/osgeo4w/package.sh
+++ b/src/qgis-qt6-rel-dev/osgeo4w/package.sh
@@ -201,9 +201,6 @@ nextbinary
 		-D WITH_CUSTOM_WIDGETS=TRUE \
 		-D CMAKE_BUILD_TYPE=$BUILDCONF \
 		-D CMAKE_CONFIGURATION_TYPES="$BUILDCONF" \
-		-D HAS_KDE_QT5_PDF_TRANSFORM_FIX=TRUE \
-		-D HAS_KDE_QT5_SMALL_CAPS_FIX=TRUE \
-		-D HAS_KDE_QT5_FONT_STRETCH_FIX=TRUE \
 		-D SETUPAPI_LIBRARY="$(cygpath -am "/cygdrive/c/Program Files (x86)/Windows Kits/10/Lib/$UCRTVersion/um/x64/SetupAPI.Lib")" \
 		-D PROJ_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \
 		-D POSTGRES_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \

--- a/src/qgis-qt6/osgeo4w/package.sh
+++ b/src/qgis-qt6/osgeo4w/package.sh
@@ -137,9 +137,6 @@ nextbinary
 		-D WITH_CUSTOM_WIDGETS=TRUE \
 		-D CMAKE_BUILD_TYPE=$BUILDCONF \
 		-D CMAKE_CONFIGURATION_TYPES="$BUILDCONF" \
-		-D HAS_KDE_QT5_PDF_TRANSFORM_FIX=TRUE \
-		-D HAS_KDE_QT5_SMALL_CAPS_FIX=TRUE \
-		-D HAS_KDE_QT5_FONT_STRETCH_FIX=TRUE \
 		-D SETUPAPI_LIBRARY="$(cygpath -am "/cygdrive/c/Program Files (x86)/Windows Kits/10/Lib/$UCRTVersion/um/x64/SetupAPI.Lib")" \
 		-D PROJ_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \
 		-D POSTGRES_INCLUDE_DIR=$(cygpath -am $O4W_ROOT/include) \


### PR DESCRIPTION
They are intended for Qt5 only and are not needed for Qt6 (the features are enabled for any Qt6 >= 6.3.0 build , whether the flags are set or not).