### PR TITLE
grass-dev: Remove python3-ply dependency as not used anymore

### DIFF
--- a/src/grass-dev/osgeo4w/package.sh
+++ b/src/grass-dev/osgeo4w/package.sh
@@ -2,7 +2,7 @@ export P=grass-dev
 export V=tbd
 export B=tbd
 export MAINTAINER=JuergenFischer
-export BUILDDEPENDS="gdal-devel proj-devel geos-devel netcdf-devel libjpeg-turbo-devel libpq-devel libpng-devel libtiff-devel sqlite3-devel zstd-devel python3-ply python3-core python3-six python3-pywin32 python3-wxpython liblas-devel cairo-devel freetype-devel"
+export BUILDDEPENDS="gdal-devel proj-devel geos-devel netcdf-devel libjpeg-turbo-devel libpq-devel libpng-devel libtiff-devel sqlite3-devel zstd-devel python3-core python3-six python3-pywin32 python3-wxpython liblas-devel cairo-devel freetype-devel"
 export PACKAGES="grass-dev"
 
 REPO=https://github.com/OSGeo/grass
@@ -175,7 +175,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*} nightly"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*} nightly)"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets
+requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets
 maintainer: $MAINTAINER
 EOF
 


### PR DESCRIPTION
PLY is not a dependency of GRASS since https://github.com/OSGeo/grass/pull/5942, where a vendored copy is used for the (GRASS) tools that need it.

Moreover, python3-six has been removed from our code since 2023, but some grass addons still might need it. I hesitated to remove it too, as I don't know if the BUILDDEPENDS and the setup.hint includes needs to include transitive dependencies or not. I remember at some point that matplotlib was a package that was still pulling in six (or one of its dependencies, they seem to have removed it in 2018, but probably their dependency python-dateutil still needs it).