### PR TITLE
grass-dev: Use new name "GRASS" for "GRASS GIS" 8.5+

### DIFF
--- a/src/grass-dev/osgeo4w/package.sh
+++ b/src/grass-dev/osgeo4w/package.sh
@@ -172,8 +172,8 @@ mv ../grass/mswindows/osgeo4w/package/$P-$major.$minor.$patch-1.tar.bz2 $R/$P-$V
 cp ../grass/COPYING $R/$P-$V-$B.txt
 
 cat <<EOF >$R/setup.hint
-sdesc: "GRASS GIS ${V%.*} nightly"
-ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*} nightly)"
+sdesc: "GRASS ${V%.*} nightly"
+ldesc: "Geographic Resources Analysis Support System (GRASS ${V%.*} nightly)"
 category: Desktop
 requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets
 maintainer: $MAINTAINER


### PR DESCRIPTION
Starting from GRASS 8.5, GRASS GIS is rebranded as GRASS. Adapt the grass-dev package.sh accordingly.

Also, there are some resource files for the installer that will need to be updated when GRASS 8.5 will be released. I don't seem to be able to open an issue in this repo to remind to do that later.