### PR TITLE
Add python3-jupyter runtime dependency for grass-dev

### DIFF
--- a/src/grass-dev/osgeo4w/package.sh
+++ b/src/grass-dev/osgeo4w/package.sh
@@ -175,7 +175,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS ${V%.*} nightly"
 ldesc: "Geographic Resources Analysis Support System (GRASS ${V%.*} nightly)"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets
+requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets python3-jupyter
 maintainer: $MAINTAINER
 EOF
 

--- a/src/grass/osgeo4w/package.sh
+++ b/src/grass/osgeo4w/package.sh
@@ -127,7 +127,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*}"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*})"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets grass8
+requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets grass8 python3-jupyter
 maintainer: $MAINTAINER
 EOF
 

--- a/src/grass/osgeo4w/package.sh
+++ b/src/grass/osgeo4w/package.sh
@@ -127,7 +127,7 @@ cat <<EOF >$R/setup.hint
 sdesc: "GRASS GIS ${V%.*}"
 ldesc: "Geographic Resources Analysis Support System (GRASS GIS ${V%.*})"
 category: Desktop
-requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets grass8 python3-jupyter
+requires: liblas $RUNTIMEDEPENDS avce00 gpsbabel proj python3-gdal python3-matplotlib libpng libtiff python3-wxpython python3-pillow python3-pip python3-ply python3-pyopengl python3-psycopg2 python3-six zstd python3-pywin32 gs netcdf wxwidgets grass8
 maintainer: $MAINTAINER
 EOF
 


### PR DESCRIPTION
For upcoming changes related to the new support for Jupyter notebooks in GRASS GUI in version 8.5 there is a need for the Jupyter dependency also on the side of OSGeo4W builds - please see the discussion in https://github.com/OSGeo/grass/pull/6289.

@jef-n Also for the full Jupyter support we would ideally need to include the interactive map python libraries, particularly ipyleaflet and folium. Is there any chance they could be added to this repo? Or could you lead me in the procedure for adding them? (I am quite new to that build issues but I will try to do my best :-)).