### PR TITLE
qgis-dev: call pdal-dev-env before executing crssync

### DIFF
--- a/src/qgis-dev/osgeo4w/postinstall.bat
+++ b/src/qgis-dev/osgeo4w/postinstall.bat
@@ -31,6 +31,7 @@ if not exist "%OSGEO4W_ROOT%\apps\qgis-ltr\bin\qgis.reg" if not exist "%OSGEO4W_
 call "%OSGEO4W_ROOT%\bin\o4w_env.bat"
 call "%OSGEO4W_ROOT%\bin\qt6_env.bat"
 call "%OSGEO4W_ROOT%\bin\gdal-dev-py-env.bat"
+call "%OSGEO4W_ROOT%\bin\pdal-dev-env.bat"
 path %PATH%;%OSGEO4W_ROOT%\apps\@package@\bin
 set QGIS_PREFIX_PATH=%OSGEO4W_ROOT:\=/%/apps/@package@
 "%OSGEO4W_ROOT%\apps\@package@\crssync"


### PR DESCRIPTION
Fix https://trac.osgeo.org/osgeo4w/ticket/905, after https://github.com/jef-n/OSGeo4W/commit/03719abea7e2345406e3852e471bbeda3aaead42.